### PR TITLE
fix(html-proofer): address linkedin and alt errors

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,24 @@
+<a href="{{ "/" | relative_url }}" class="logo">
+    {%- if site.logo -%}
+    <img src="{{ site.logo | img_url_prefix }}" class="logo_img" alt="| Home |">
+    {%- endif -%}
+    <h1>{{ site.title }}</h1>
+  </a>
+  {%- if "slides,chapter,book" contains page.layout and site.theme_setting.archive_page -%}
+  {%- assign archive_page = site.pages | where: "path", site.theme_setting.archive_page | first -%}
+  <a href="{{ archive_page.url | relative_url }}" class="sidebar__toggler">
+    <span class="sidebar__toggler_top"></span>
+    <span class="sidebar__toggler_middle"></span>
+    <span class="sidebar__toggler_bottom"></span>
+  </a>
+  {%- endif %}
+  {%- if page.layout == "chapter" -%}
+  <div class="book-header" role="navigation">
+      <a href="#" id="summaryToggler" class="summary__toggler">
+        {% include icons/ellipsis.html%}
+      </a>
+    <h1>
+      {{ page.title }} - {{ page.book.title }}
+    </h1>
+  </div>
+  {%- endif -%}

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,4 +2,4 @@
 set -e # halt script on error
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site
+bundle exec htmlproofer ./_site --url-ignore '/www.linkedin.com/'


### PR DESCRIPTION
**Change List**


1. Ignore LinkedIn url check in `html-proofer` for Travis CI.
   -  Per the issue mentioned [here](https://github.com/gjtorikian/html-proofer/issues/215), LinkedIn urls return a `999` error.

1. Add `alt` to logo image by overriding theme `_includes/header.html`.
